### PR TITLE
add PORT option for starting process

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ $ cp app/src/config.template.js app/src/config.js
 $ npm install
 # Start the server
 $ npm start
+# If you want to start the server on a different port than the default use an env var
+$ PORT=3011 npm start
 ```
 
 -   Open https://localhost:3010 in browser

--- a/app/src/config.template.js
+++ b/app/src/config.template.js
@@ -32,7 +32,7 @@ module.exports = {
     hostPassword: 'password',
     // app listen on
     listenIp: '0.0.0.0',
-    listenPort: 3010,
+    listenPort: process.env.PORT || 3010,
     // ssl/README.md
     sslCrt: '../ssl/cert.pem',
     sslKey: '../ssl/key.pem',


### PR DESCRIPTION
This allows us to use `PORT={some other port than 3010 default} npm start` in the event of running more than one service on the same network/machine.